### PR TITLE
feat: passage à manifest v3

### DIFF
--- a/doctolib/manifest.json
+++ b/doctolib/manifest.json
@@ -1,16 +1,11 @@
-{  "manifest_version": 2,
+{
+  "manifest_version": 3,
   "name": "Trans Doctolib",
   "version": "1.0",
   "description": "Trans Doctolib est une extension pour Google Chrome qui permet de voir sur le profil Doctolib d'un praticien, s'il a signé une tribune pro ou anti-trans et d'accèder à la tribune en question en un clique.",
-  "icons": {    "48": "icons/logo.png"  },
+  "icons": { "48": "icons/logo.png" },
   "content_scripts": [
-  {      "matches": ["*://*.doctolib.fr/*"],
-      "js": ["paint_red.js"]    } 
-	  ],
-	"permissions": [
-  "storage",
-  "webRequest", 
-  "webRequestBlocking",
-  "*://localhost/*"
-]
+    { "matches": ["*://*.doctolib.fr/*"], "js": ["paint_red.js"] }
+  ],
+  "permissions": ["storage", "webRequest", "declarativeNetRequest"]
 }


### PR DESCRIPTION
Passer l'extension à Manifest v3 permet deux choses : 
- ne pas être bloqué le mois prochain quand Manifest v3 va être déprécié
- permet d'être compatible avec Firefox 😄 
![CleanShot 2024-05-29 at 23 33 54@2x](https://github.com/msw9/trans-doctolib/assets/3597738/970672ea-3547-4821-95e0-746570023a82)
