### PR TITLE
Move color to a separate label, add a tooltip

### DIFF
--- a/doctolib/paint_red.js
+++ b/doctolib/paint_red.js
@@ -1,46 +1,134 @@
 const name = document.getElementById("profile-name-with-title");
-const icone = document.createElement('span');
-const lien = document.createElement('a');
-const allEqual = (arr,x) =>arr.every(val => x.includes(val));
-// charger les icônes
-function iconsLoader(){
-	const lien = document.createElement('link');
-	lien.rel = 'stylesheet';
-	lien.href = 'https://fonts.googleapis.com/icon?family=Material+Icons';
-	document.head.appendChild(lien);
+const allEqual = (arr, x) => arr.every(val => x.includes(val));
+
+// Charger les icônes
+function iconsLoader() {
+    const lien = document.createElement('link');
+    lien.rel = 'stylesheet';
+    lien.href = 'https://fonts.googleapis.com/icon?family=Material+Icons';
+    document.head.appendChild(lien);
 }
 iconsLoader();
-// créer icône à côté du nom
 
-// main
+// Main
 fetch('https://raw.githubusercontent.com/msw9/trans-doctolib-ressources/main/doctolib.json')
-  .then(function(response) {
-    return response.json();
-  })
-  .then(function(docteurs) {
-  for (let i=0;i < docteurs.length;i++){
-	if (allEqual(docteurs[i]['noms'].toLowerCase().split(' '),name.querySelector("span").textContent.toLowerCase())){
-		if (docteurs[i]['transfriendly']==='False'){
-			name.style.color = "red";
-			icone.setAttribute("class","material-icons");
-			icone.style.paddingLeft = "20px";
-			icone.style.color = "red";
-			icone.textContent = "newspaper";
-			lien.href = docteurs[i]['source'];
-			lien.appendChild(icone);
-			name.appendChild(lien);
-			break;
-		} else if (docteurs[i]['transfriendly']==='True'){
-			name.style.color = "green";
-			icone.setAttribute("class","material-icons");
-			icone.style.paddingLeft = "20Px";
-			icone.style.color = "green";
-			icone.textContent = "newspaper";
-			lien.href = docteurs[i]['source'];
-			lien.appendChild(icone);
-			name.appendChild(lien);
-			break;
-		}
-	}
+    .then(response => response.json())
+    .then(docteurs => {
+        fetch('https://raw.githubusercontent.com/msw9/trans-doctolib-ressources/main/sources.csv')
+            .then(response => response.text())
+            .then(csvText => {
+                const sources = parseCSV(csvText);
+                for (let i = 0; i < docteurs.length; i++) {
+                    if (allEqual(docteurs[i]['noms'].toLowerCase().split(' '), name.querySelector("span").textContent.toLowerCase())) {
+                        const label = document.createElement('span'); // Create a new span for the label
+                        const icone = document.createElement('span'); // Create a span for the icon
+                        icone.setAttribute("class", "material-icons");
+                        icone.style.marginRight = "5px";
+                        icone.style.fontSize = "18px";
+                        icone.textContent = "newspaper";
+
+                        if (docteurs[i]['transfriendly'] === 'False') {
+                            label.style.backgroundColor = "#fecaca";
+                            label.style.color = "#991b1b";
+                            label.style.padding = "2px 10px";
+                            label.style.borderRadius = "20px";
+                            label.style.marginLeft = "10px"; // Adjust margin if needed
+                            label.textContent = "Trans not friendly";
+                            label.style.display = "inline-flex";
+                            label.style.alignItems = "center";
+                            label.style.fontSize = "16px";
+                        } else if (docteurs[i]['transfriendly'] === 'True') {
+                            label.style.backgroundColor = "#bbf7d0";
+                            label.style.color = "#166534";
+                            label.style.padding = "2px 10px";
+                            label.style.borderRadius = "20px";
+                            label.style.marginLeft = "10px"; // Adjust margin if needed
+                            label.textContent = "Trans friendly";
+                            label.style.display = "inline-flex";
+                            label.style.alignItems = "center";
+                            label.style.fontSize = "16px";
+                        }
+
+                        label.insertBefore(icone, label.firstChild);
+                        const lien = document.createElement('a');
+                        lien.href = docteurs[i]['source'];
+                        lien.appendChild(label);
+                        name.appendChild(lien);
+
+                        addTooltip(lien, sources[docteurs[i]['source']]);
+                        break;
+                    }
+                }
+            });
+    });
+
+function parseCSV(csvText) {
+    const lines = csvText.split('\n');
+    const headers = lines[0].split(';');
+    const result = {};
+
+    for (let i = 1; i < lines.length; i++) {
+        const obj = {};
+        const currentLine = lines[i].split(';');
+        for (let j = 0; j < headers.length; j++) {
+            obj[headers[j].trim()] = currentLine[j] ? currentLine[j].trim() : "";
+        }
+        result[obj['Lien']] = obj;
+    }
+
+    return result;
 }
-  });
+
+function addTooltip(linkElement, source) {
+    const tooltip = document.createElement('div');
+    tooltip.style.position = 'absolute';
+    tooltip.style.backgroundColor = '#FFFFFF';
+    tooltip.style.border = '1px solid #F2F2F2';
+    tooltip.style.padding = '10px';
+    tooltip.style.display = 'none';
+    tooltip.style.zIndex = '1000';
+    tooltip.style.maxWidth = '500px';
+    tooltip.style.borderRadius = '6px';
+    tooltip.style.boxShadow = '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)';
+    tooltip.style.cursor = 'pointer';
+
+    tooltip.innerHTML = `<strong style="font-size: 20px; line-height: 24px;">${source.Titre}</strong>
+                        <hr style="margin-bottom: 8px; margin-top: 8px;">
+                        <span style="font-size: 16px;">${source.Abstract}</span>
+                        <br>
+                        <span style="font-size: 16px; color: #107aca; text-decoration: underline; padding-top: 8px; margin-left: auto; display: block; text-align: right;">Lire l'article ↗</span>`;
+
+    document.body.appendChild(tooltip);
+
+    // Update the link element to open in a new tab
+    linkElement.setAttribute('target', '_blank');
+
+    linkElement.addEventListener('mouseenter', function () {
+        const rect = linkElement.getBoundingClientRect();
+        tooltip.style.top = rect.bottom + 'px';
+        tooltip.style.left = rect.left + 'px';
+        tooltip.style.display = 'block';
+    });
+
+    linkElement.addEventListener('mouseleave', function () {
+        setTimeout(() => {
+            if (!tooltip.matches(':hover')) {
+                tooltip.style.display = 'none';
+            }
+        }, 300);
+    });
+
+    tooltip.addEventListener('mouseenter', function () {
+        tooltip.style.display = 'block';
+    });
+
+    tooltip.addEventListener('mouseleave', function () {
+        tooltip.style.display = 'none';
+    });
+
+    // Make the tooltip clickable
+    tooltip.addEventListener('click', function () {
+        window.open(source.Lien, '_blank');
+    });
+}
+


### PR DESCRIPTION
fix #3 Améliorer l'accessibilité des textes

- Les couleurs de signature de papier pro ou anti trans sont déplacées dans un label dont le choix des couleur respecte le WCAG pour améliorer la lisibilité pour tous
![image](https://github.com/msw9/trans-doctolib/assets/10211651/be64d112-0904-4ce5-a27c-85163bab6f8d)
![image](https://github.com/msw9/trans-doctolib/assets/10211651/4c48fc53-3f9f-47ec-9495-ebed59685f09)
![image](https://github.com/msw9/trans-doctolib/assets/10211651/b0fa2e43-d1e6-4e23-8930-8a6d772ea6b5)
![image](https://github.com/msw9/trans-doctolib/assets/10211651/d59daf43-4f74-4315-9234-73f3f19ba267)

- Au survol du label, un tooltip avec le titre et l'abstract de l'article sont récupérés du repo [trans-doctolib-ressources](https://github.com/msw9/trans-doctolib-ressources)
![image](https://github.com/msw9/trans-doctolib/assets/10211651/0e09878a-2a35-4c9a-ba77-36ba01f2b916)

- Le lien de l'article s'ouvre dans un nouvel onglet